### PR TITLE
docs: add credential revocation propagation

### DIFF
--- a/jupyter/notebooks/101_70_ACDC_Presentation_and_Revocation.ipynb
+++ b/jupyter/notebooks/101_70_ACDC_Presentation_and_Revocation.ipynb
@@ -27,7 +27,7 @@
    "source": [
     "<div class=\"alert alert-primary\">\n",
     "<b>🎯 OBJECTIVE</b><hr>\n",
-    "Demonstrate how a Holder presents a previously issued ACDC or Verifiable Credential (VC) to a Verifier using the Issuance and Presentation Exchange (IPEX) protocol. And also covers the process of credential revocation by the Issuer.\n",
+    "Demonstrate how a Holder presents a previously issued ACDC or Verifiable Credential (VC) to a Verifier using the Issuance and Presentation Exchange (IPEX) protocol and understand how IPEX allows credential holders (issuees) to sign that they agree with the terms of a credential. And also covers the process of credential revocation by the Issuer.\n",
     "</div>"
    ]
   },
@@ -44,7 +44,11 @@
    "source": [
     "## Credential Presentation Overview\n",
     "\n",
-    "In the previous notebook, you saw how an Issuer creates and sends an ACDC to a Holder. Now, we'll focus on the next step in the typical verifiable credential lifecycle: presentation. The Holder, possessing the credential, needs to present it to another party (the Verifier) to prove certain claims or gain access to something. You will again use the IPEX protocol for this exchange, but this time initiated by the Holder. Finally, you will see how the original Issuer can revoke the credential."
+    "In the previous notebook, you saw how an Issuer creates and sends an ACDC to a Holder. Now, we'll focus on the next steps in the typical verifiable credential lifecycle: presentation and admittance.\n",
+    "\n",
+    "After creating the credential the Issuer must present it to the Holder. In IPEX this presentation is called an IPEX Grant message. After receiving the IPEX Grant message the Holder can then accept the credential by performing an IPEX Admit message. In the prior training this Grant and Admit process were explained.\n",
+    "\n",
+    "In this training, following the reception of a credential, the Holder will present it to another party (the Verifier) to prove certain claims or gain access to something. You will again use the IPEX protocol for this exchange, but this time initiated by the Holder. Finally, you will see how the original Issuer can revoke the credential."
    ]
   },
   {
@@ -73,6 +77,7 @@
    "execution_count": null,
    "id": "f2b8cee2-1b47-44d3-b8e3-4916f426cda8",
    "metadata": {
+    "editable": false,
     "slideshow": {
      "slide_type": ""
     },
@@ -110,7 +115,7 @@
     "    --config-dir ./config \\\n",
     "    --config-file keystore_init_config.json\n",
     "\n",
-    "!kli incept --name {issuer_keystore_name} --passcode {issuer_keystore_passcode} --alias {issuer_aid}  \\\n",
+    "!kli incept --name {issuer_keystore_name} --passcode {issuer_keystore_passcode} --alias {issuer_aid}\\\n",
     "    --file ./config/aid_inception_config.json\n",
     "\n",
     "# Issuer registry inception\n",
@@ -123,28 +128,30 @@
     "\n",
     "# Issuer and Holder oobi\n",
     "\n",
-    "holder_oobi_gen = f\"kli oobi generate --name {holder_keystore_name} --alias {holder_aid} --passcode {holder_keystore_passcode} --role witness\"\n",
+    "holder_oobi_gen = f\"kli oobi generate --name {holder_keystore_name} --alias {holder_aid}\\\n",
+    "  --passcode {holder_keystore_passcode} --role witness\"\n",
     "holder_oobi = exec(holder_oobi_gen)\n",
     "\n",
-    "issuer_oobi_gen = f\"kli oobi generate --name {issuer_keystore_name} --alias {issuer_aid} --passcode {issuer_keystore_passcode} --role witness\"\n",
+    "issuer_oobi_gen = f\"kli oobi generate --name {issuer_keystore_name} --alias {issuer_aid}\\\n",
+    "  --passcode {issuer_keystore_passcode} --role witness\"\n",
     "issuer_oobi = exec(issuer_oobi_gen)\n",
     "\n",
-    "!kli oobi resolve --name {holder_keystore_name} --passcode {holder_keystore_passcode} --oobi-alias {issuer_aid} \\\n",
-    "    --oobi {issuer_oobi}\n",
+    "!kli oobi resolve --name {holder_keystore_name} --passcode {holder_keystore_passcode}\\\n",
+    "  --oobi-alias {issuer_aid} --oobi {issuer_oobi}\n",
     "\n",
-    "!kli oobi resolve --name {issuer_keystore_name} --passcode {issuer_keystore_passcode} --oobi-alias {holder_aid}\\\n",
-    "    --oobi {holder_oobi}\n",
+    "!kli oobi resolve --name {issuer_keystore_name} --passcode {issuer_keystore_passcode}\\\n",
+    "  --oobi-alias {holder_aid} --oobi {holder_oobi}\n",
     "\n",
     "# Issuer and Holder resolve schema oobis\n",
     "schema_oobi_alias = \"schema_oobi\"\n",
     "schema_said = get_schema_said(\"config/schemas/event_pass_schema.json\")\n",
     "schema_oobi = f\"http://vlei-server:7723/oobi/{schema_said}\"\n",
     "\n",
-    "!kli oobi resolve --name {holder_keystore_name} --passcode {holder_keystore_passcode} --oobi-alias {schema_oobi_alias} \\\n",
-    "    --oobi {schema_oobi}\n",
+    "!kli oobi resolve --name {holder_keystore_name} --passcode {holder_keystore_passcode}\\\n",
+    "    --oobi-alias {schema_oobi_alias} --oobi {schema_oobi}\n",
     "\n",
-    "!kli oobi resolve --name {issuer_keystore_name} --passcode {issuer_keystore_passcode} --oobi-alias {schema_oobi_alias}\\\n",
-    "    --oobi {schema_oobi}\n",
+    "!kli oobi resolve --name {issuer_keystore_name} --passcode {issuer_keystore_passcode}\\\n",
+    "    --oobi-alias {schema_oobi_alias} --oobi {schema_oobi}\n",
     "\n",
     "# Issuer create VC\n",
     "time = exec(\"kli time\")\n",
@@ -158,7 +165,9 @@
     "    --time {time}\n",
     "\n",
     "# Get credential said\n",
-    "get_credential_said = f\"kli vc list --name {issuer_keystore_name} --passcode {issuer_keystore_passcode} --alias {issuer_aid} --issued --said --schema {schema_said}\"\n",
+    "get_credential_said = f\"kli vc list --name {issuer_keystore_name}\\\n",
+    "  --passcode {issuer_keystore_passcode} --alias {issuer_aid}\\\n",
+    "  --issued --said --schema {schema_said}\"\n",
     "credential_said=exec(get_credential_said)\n",
     "\n",
     "#Issuer grant credential\n",
@@ -173,7 +182,8 @@
     "\n",
     "# Holder poll and admit credential\n",
     "\n",
-    "get_ipex_said=f\"kli ipex list --name {holder_keystore_name} --passcode {holder_keystore_passcode} --alias {holder_aid} --poll --said\"\n",
+    "get_ipex_said=f\"kli ipex list --name {holder_keystore_name} --passcode {holder_keystore_passcode}\\\n",
+    "  --alias {holder_aid} --poll --said\"\n",
     "ipex_said=exec(get_ipex_said)\n",
     "\n",
     "time = exec(\"kli time\")\n",
@@ -299,18 +309,19 @@
    },
    "outputs": [],
    "source": [
-    "holder_oobi_gen = f\"kli oobi generate --name {holder_keystore_name} --alias {holder_aid} --passcode {holder_keystore_passcode} --role witness\"\n",
+    "holder_oobi_gen = f\"kli oobi generate --name {holder_keystore_name} --alias {holder_aid}\\\n",
+    "    --passcode {holder_keystore_passcode} --role witness\"\n",
     "holder_oobi = exec(holder_oobi_gen)\n",
     "\n",
-    "verifier_oobi_gen = f\"kli oobi generate --name {verifier_keystore_name} --alias {verifier_aid} --passcode {verifier_keystore_passcode} --role witness\"\n",
+    "verifier_oobi_gen = f\"kli oobi generate --name {verifier_keystore_name} --alias {verifier_aid}\\\n",
+    "    --passcode {verifier_keystore_passcode} --role witness\"\n",
     "verifier_oobi = exec(verifier_oobi_gen)\n",
     "\n",
-    "!kli oobi resolve --name {holder_keystore_name} --passcode {holder_keystore_passcode} --oobi-alias {verifier_aid} \\\n",
-    "    --oobi {verifier_oobi}\n",
+    "!kli oobi resolve --name {holder_keystore_name} --passcode {holder_keystore_passcode}\\\n",
+    "    --oobi-alias {verifier_aid} --oobi {verifier_oobi}\n",
     "\n",
-    "!kli oobi resolve --name {verifier_keystore_name} --passcode {verifier_keystore_passcode} --oobi-alias {holder_aid}\\\n",
-    "    --oobi {holder_oobi}\n",
-    "\n"
+    "!kli oobi resolve --name {verifier_keystore_name} --passcode {verifier_keystore_passcode}\\\n",
+    "    --oobi-alias {holder_aid} --oobi {holder_oobi}"
    ]
   },
   {
@@ -342,8 +353,8 @@
    },
    "outputs": [],
    "source": [
-    "!kli oobi resolve --name {verifier_keystore_name} --passcode {verifier_keystore_passcode} --oobi-alias {schema_oobi_alias}\\\n",
-    "    --oobi {schema_oobi}"
+    "!kli oobi resolve --name {verifier_keystore_name} --passcode {verifier_keystore_passcode}\\\n",
+    "    --oobi-alias {schema_oobi_alias} --oobi {schema_oobi}"
    ]
   },
   {
@@ -359,14 +370,14 @@
    "source": [
     "### Step 1: Holder Presents Credential (Grant)\n",
     "\n",
-    "Now, the Holder initiates the IPEX exchange to present the credential to the Verifier. The Holder acts as the \"Discloser\" in this context. The command used is `kli ipex grant`, just like in issuance, but the roles are reversed in intent.\n",
+    "Now, the Holder initiates the IPEX exchange to present the credential to the Verifier. The Holder acts as the \"Discloser\" in this context. The command used is `kli ipex grant`, just like in issuance, but the IPEX roles are reversed so the Holder is the discloser and the Verifier is the disclosee.\n",
     "\n",
     "- `--name`, `--passcode`, `--alias`: Identify the Holder's keystore and AID.\n",
     "- `--said`: The SAID of the credential being presented.\n",
     "- `--recipient`: The AID of the Verifier who should receive the presentation.\n",
     "- `--time`: A timestamp for the grant message.\n",
     "\n",
-    "This sends an IPEX grant message, effectively offering the credential presentation to the Verifier."
+    "This sends an IPEX Grant message, effectively offering the credential presentation to the Verifier."
    ]
   },
   {
@@ -395,6 +406,25 @@
   },
   {
    "cell_type": "markdown",
+   "id": "fb7bad72-9a6b-404d-bc43-2ca7105ca64f",
+   "metadata": {
+    "editable": false,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
+   "source": [
+    "Receiving the Grant message triggers the Verifier's KERI controller to perform several checks automatically:\n",
+    "\n",
+    "- Schema Validation: Checks whether the credential structure and data types match the resolved schema.\n",
+    "- Issuer Authentication: Verifies the credential signature against the Issuer's KEL (previously retrieved via OOBI) and, importantly, checks the credential's status (e.g., not revoked) against the Issuer's registry (TEL).\n",
+    "\n",
+    "If all checks pass, the Verifier may admit the ACDC, store the validated credential information, and send an IPEX Admit message back to the Holder."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "445decdb-099c-43ac-81c0-6517e0485d61",
    "metadata": {
     "editable": false,
@@ -406,7 +436,9 @@
    "source": [
     "### Step 2: Verifier Receives Presentation\n",
     "\n",
-    "The Verifier needs to check its KERI mailbox for the incoming grant message containing the credential presentation.Use `kli ipex list --poll` and extract the SAID of the message."
+    "The Verifier needs to check its KERI mailbox(es) for the incoming grant message containing the credential presentation.\n",
+    "\n",
+    "Use `kli ipex list --poll` to check the mailbox(es) and extract the SAID of the IPEX Grant message."
    ]
   },
   {
@@ -422,10 +454,13 @@
    },
    "outputs": [],
    "source": [
-    "get_ipex_said=f\"kli ipex list --name {verifier_keystore_name} --passcode {verifier_keystore_passcode} --alias {verifier_aid} --poll --said\"\n",
+    "get_ipex_said=f\"kli ipex list --name {verifier_keystore_name} --passcode {verifier_keystore_passcode}\\\n",
+    "    --alias {verifier_aid} --poll --said\"\n",
     "ipex_said=exec(get_ipex_said)\n",
     "\n",
-    "print(ipex_said)"
+    "print(ipex_said)\n",
+    "\n",
+    "pr_continue()"
    ]
   },
   {
@@ -477,12 +512,7 @@
    "source": [
     "### Step 3: Verifier Admits and Validates Presentation\n",
     "\n",
-    "The Verifier uses the `kli ipex admit` command to accept the presentation. This triggers the Verifier's KERI controller to perform several checks automatically:\n",
-    "\n",
-    "- Schema Validation: Checks whether the credential structure and data types match the resolved schema.\n",
-    "- Issuer Authentication: Verifies the credential signature against the Issuer's KEL (previously retrieved via OOBI) and, importantly, checks the credential's status (e.g., not revoked) against the Issuer's registry (TEL).\n",
-    "\n",
-    "If all checks pass, the Verifier sends an admit message back to the Holder and stores the validated credential information."
+    "The Verifier uses the `kli ipex admit` command to accept the presentation.\n"
    ]
   },
   {
@@ -555,20 +585,8 @@
     "tags": []
    },
    "source": [
-    "## Credential Revocation by Issuer"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "62095632-1ab7-41c8-9b36-c1ee73aa0b69",
-   "metadata": {
-    "editable": false,
-    "slideshow": {
-     "slide_type": ""
-    },
-    "tags": []
-   },
-   "source": [
+    "## Credential Revocation by Issuer\n",
+    "\n",
     "Credentials may need to be invalidated before their natural expiry (if any). This process is called revocation. In KERI/ACDC, revocation is performed by the original Issuer of the credential. The Issuer records a revocation event in the credential registry's Transaction Event Log (TEL), which is anchored to the Issuer's main KEL.\n",
     "\n",
     "The `kli vc revoke` command is used by the Issuer:\n",
@@ -628,7 +646,126 @@
    "source": [
     "!kli vc list --name {issuer_keystore_name} --passcode {issuer_keystore_passcode} \\\n",
     "    --alias {issuer_aid} \\\n",
-    "    -i"
+    "    --issued"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "25b3e476-ca7a-4a00-b186-21a5d1bc3449",
+   "metadata": {
+    "editable": false,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
+   "source": [
+    "### Sharing the revoked credential status with the Holder.\n",
+    "Revoking a credential is an important event that should be shared with verifiers. One way to share a revocation with a verifier is to share the revocation of a credential with the Holder. After the Holder receives that revoked credential status then it can re-present the revoked credential to a verifier so that the verifier may know the credential is revoked.\n",
+    "\n",
+    "To accomplish this sharing of revocation state the issuer may perform another IPEX Grant of the credential following revocation. Then the Holder must again perform an IPEX Admit in order to learn of this revocation state.\n",
+    "\n",
+    "<div class=\"alert alert-info\">\n",
+    "<b>ℹ️ NOTE:</b><hr> \n",
+    "Use of an Observer node to learn of an ACDC credential state is another way for a verifier to learn of the revocation state of a credential. While standalone observers are under development, a witness of a controller may be used to query for credential state using the following request format:\n",
+    "<br/><br/>\n",
+    "<b>`HTTP GET`</b> to a witness host on the `/query` endpoint with URL parameters like so:\n",
+    "\n",
+    "- `/query?typ=tel&amp;reg=EHrbPfpRLU9wpFXTzGY-LIo2FjMiljjEnt238eWHb7yZ&amp;vcid=EO5y0jMXS5XKTYBKjCUPmNKPr1FWcWhtKwB2Go2ozvr0`\n",
+    "\n",
+    "A full query to a witness would look like so:\n",
+    "- `https://wit1.testnet.gleif.org:5641/query?typ=tel&reg=EHrbPfpRLU9wpFXTzGY-LIo2FjMiljjEnt238eWHb7yZ&vcid=EO5y0jMXS5XKTYBKjCUPmNKPr1FWcWhtKwB2Go2ozvr0`\n",
+    "</div>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1660a5ea-de0a-4fe2-a0fa-3b84b79e60ff",
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
+   "source": [
+    "### Presenting a revoked credential\n",
+    "\n",
+    "Now the holder can present the revoked credential to the verifier and the verifier can understand that the credential is revoke."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5ad61efe-eaa4-4cde-867f-1a851936ae98",
+   "metadata": {
+    "editable": false,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# Issuer grants the now revoked credential\n",
+    "time = exec(\"kli time\")\n",
+    "\n",
+    "!kli ipex grant \\\n",
+    "    --name {issuer_keystore_name} --passcode {issuer_keystore_passcode} \\\n",
+    "    --alias {issuer_aid} \\\n",
+    "    --said {credential_said} \\\n",
+    "    --recipient {holder_aid} \\\n",
+    "    --time {time}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4947a356-d739-4949-b8fc-004f93d2ae63",
+   "metadata": {
+    "editable": false,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# Holder polls and admits the revoked credential\n",
+    "# The pipe to \"tail -n 1\" makes sure to get the last IPEX Grant which will be the grant sharing the re\n",
+    "get_ipex_said=f\"kli ipex list --name {holder_keystore_name} --passcode {holder_keystore_passcode}\\\n",
+    "  --alias {holder_aid} --poll --said | tail -n 1 | tr -d '' \"\n",
+    "ipex_said=exec(get_ipex_said)\n",
+    "\n",
+    "print(f\"Found grant {ipex_said} for revocation\")\n",
+    "\n",
+    "time = exec(\"kli time\")\n",
+    "\n",
+    "!kli ipex admit \\\n",
+    "    --name {holder_keystore_name} \\\n",
+    "    --passcode {holder_keystore_passcode} \\\n",
+    "    --alias {holder_aid} \\\n",
+    "    --said {ipex_said} \\\n",
+    "    --time {time}\n",
+    "\n",
+    "pr_continue()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4402fbb8-815c-4a86-882b-3013ff63e7ab",
+   "metadata": {
+    "editable": false,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "!kli vc list --name {holder_keystore_name} --passcode {holder_keystore_passcode} \\\n",
+    "    --alias {holder_aid}"
    ]
   },
   {
@@ -646,19 +783,21 @@
     "<b>📝 SUMMARY</b><hr>\n",
     "This notebook demonstrated the ACDC presentation and revocation flows:\n",
     "<ol>\n",
-    "<li><b>Prerequisites:</b> We started with a Holder possessing an issued credential from an Issuer (established via the recap section).</li>\n",
-    "<li><b>Verifier Setup:</b> A Verifier established its KERI identity (AID).</li>\n",
-    "<li><b>Connectivity:</b> The Holder and Verifier exchanged and resolved OOBIs. The Verifier also resolved the credential's schema OOBI to enable validation.</li>\n",
-    "<li><b>Presentation (IPEX):</b>\n",
+    "    <li><b>Prerequisites:</b> We started with a Holder possessing an issued credential from an Issuer (established via the recap section).</li>\n",
+    "    <li><b>Verifier Setup:</b> A Verifier established its KERI identity (AID).</li>\n",
+    "    <li><b>Connectivity:</b> The Holder and Verifier exchanged and resolved OOBIs. The Verifier also resolved the credential's schema OOBI to enable validation.</li>\n",
+    "    <li><b>Presentation (IPEX):</b>\n",
     "<ul>\n",
-    "<li>Holder initiated the presentation using kli ipex grant, sending the credential to the Verifier.</li>\n",
-    "<li>Verifier polled its mailbox (kli ipex list --poll) to receive the presentation.</li>\n",
-    "<li>Verifier accepted and validated the presentation using kli ipex admit. Validation included schema checks, issuer authentication (KEL), and registry status checks (TEL).</li>\n",
+    "    <li>Holder initiated the presentation using kli ipex grant, sending the credential to the Verifier.</li>\n",
+    "    <li>Verifier polled its mailbox (kli ipex list --poll) to receive the presentation.</li>\n",
+    "    <li>Verifier accepted and validated the presentation using kli ipex admit. Validation included schema checks, issuer authentication (KEL), and registry status checks (TEL).</li>\n",
     "</ul>\n",
     "</li>\n",
     "<li><b>Revocation:</b>\n",
     "<ul>\n",
-    "<li>The original Issuer revoked the credential using kli vc revoke, updating the status in the credential registry's TEL.</li>\n",
+    "    <li>The original Issuer revoked the credential using kli vc revoke, updating the status in the credential registry's TEL.</li>\n",
+    "    <li>The Issuer then presented via IPEX Grant the revoked credential to the Holder.</li>    \n",
+    "    <li>The Holder then received the revoked credential via IPEX Admit.</li>\n",
     "</ul>\n",
     "</li>\n",
     "</ol>\n",


### PR DESCRIPTION
Added revocation propagation between the issuer and the holder.
Added a short callout to observers deployed with witnesses.