### PR TITLE
docs: add chainlink CCID training reference

### DIFF
--- a/jupyter/notebooks/000_Table_of_Contents.ipynb
+++ b/jupyter/notebooks/000_Table_of_Contents.ipynb
@@ -212,6 +212,7 @@
     "        1. [Training Provider Issues Credential](101_85_ACDC_Chained_Credentials_NI2I.ipynb#Training-Provider-Issues-Credential)\n",
     "        1. [Step 2: Employee Skill Credential Issuance (Company to Employee)](101_85_ACDC_Chained_Credentials_NI2I.ipynb#Step-2:-Employee-Skill-Credential-Issuance-Company-to-Employee)\n",
     "        1. [Step 3: Company Grants, Employee Admits Skill Credential](101_85_ACDC_Chained_Credentials_NI2I.ipynb#Step-3:-Company-Grants-Employee-Admits-Skill-Credential)\n",
+    "\n",
     "## vLEI 102 - Basics: Implementation\n",
     "1. [Introducing KERIA and Signify-ts: Architecture and Concepts](102_05_KERIA_Signify.ipynb#Introducing-KERIA-and-Signify-ts:-Architecture-and-Concepts)\n",
     "    1. [Client-Agent Architecture](102_05_KERIA_Signify.ipynb#Client-Agent-Architecture)\n",
@@ -269,6 +270,7 @@
     "        1. [Step 5: Verifier Receives Offer](102_25_KERIA_Signify_Credential_Presentation_and_Revocation.ipynb#Step-5:-Verifier-Receives-Offer)\n",
     "        1. [Step 6: Verifier Agrees and Validates](102_25_KERIA_Signify_Credential_Presentation_and_Revocation.ipynb#Step-6:-Verifier-Agrees-and-Validates)\n",
     "    1. [Credential Revocation by Issuer](102_25_KERIA_Signify_Credential_Presentation_and_Revocation.ipynb#Credential-Revocation-by-Issuer)\n",
+    "\n",
     "## vLEI 103 - Basics: vLEI Ecosystem\n",
     "1. [The GLEIF verifiable LEI (vLEI) Ecosystem](103_05_vLEI_Ecosystem.ipynb#The-GLEIF-verifiable-LEI-vLEI-Ecosystem)\n",
     "    1. [Introduction to the vLEI](103_05_vLEI_Ecosystem.ipynb#Introduction-to-the-vLEI)\n",
@@ -297,7 +299,19 @@
     "        1. [Step 6 (Path 1): ECR Credential - LE directly issues an Engagement Context Role credential to the Role holder](103_10_vLEI_Trust_Chain.ipynb#Step-6-Path-1:-ECR-Credential---LE-directly-issues-an-Engagement-Context-Role-credential-to-the-Role-holder)\n",
     "        1. [Step 6 (Path 2): ECR Credential - QVI issues another ECR credential using the AUTH credential](103_10_vLEI_Trust_Chain.ipynb#Step-6-Path-2:-ECR-Credential---QVI-issues-another-ECR-credential-using-the-AUTH-credential)\n",
     "    1. [The vLEI Reporting Agent](103_10_vLEI_Trust_Chain.ipynb#The-vLEI-Reporting-Agent)\n",
-    "        1. [The Presentation Workflow](103_10_vLEI_Trust_Chain.ipynb#The-Presentation-Workflow)"
+    "        1. [The Presentation Workflow](103_10_vLEI_Trust_Chain.ipynb#The-Presentation-Workflow)\n",
+    "      \n",
+    "## vLEI 201 - Intermediate (WIP): Building a Verifier\n",
+    "\n",
+    "## vLEI 202 - Intermediate (WIP): Signing and Verification Thresholds\n",
+    "\n",
+    "## vLEI 203 - Intermediate (WIP): Credential State Verification with Observers\n",
+    "\n",
+    "## vLEI 204 - Intermediate (WIP): Event Types and Communication Modes\n",
+    "\n",
+    "## vLEI 220 - Intermediate: Third Party and Partner Integrations and Tutorials\n",
+    "\n",
+    "1. [220-10 Integrating Chainlink CCID with vLEI](./220_10_Integrating_Chainlink_CCID_with_vLEI.ipynb)"
    ]
   },
   {

--- a/jupyter/notebooks/220_10_Integrating_Chainlink_CCID_with_vLEI.ipynb
+++ b/jupyter/notebooks/220_10_Integrating_Chainlink_CCID_with_vLEI.ipynb
@@ -1,0 +1,68 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "f64d5ed0-95e4-40e7-81bb-d973a8efe57b",
+   "metadata": {},
+   "source": [
+    "# Chainlink Automated Compliance Engine (ACE): Extending vLEI into the Blockchain World\n",
+    "🎯 OBJECTIVE\n",
+    "Introduce the Chainlink Automated Compliance Engine (ACE) as a solution that extends vLEI credentials into blockchain applications, helping organizations to maintain their regulatory compliance across traditional and decentralized systems."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b61ab67b-cf62-4fb7-9808-9b34f8e39df7",
+   "metadata": {},
+   "source": [
+    "## The Bridge Between Two Worlds\n",
+    "\n",
+    "As organizations increasingly adopt blockchain technology, they face a critical challenge: how to maintain the trust and compliance standards of traditional systems while leveraging the innovation of decentralized networks. The [Chainlink Automated Compliance Engine](https://chain.link/automated-compliance-engine) provides the bridge between these worlds, allowing vLEI credentials to seamlessly function in blockchain environments.\n",
+    "\n",
+    "## What is the Chainlink Automated Compliance Engine?\n",
+    "The Chainlink Automated Compliance Engine (ACE) unifies Chainlink’s compliance-related capabilities, tools, and services to facilitate the creation and lifecycle management of regulated financial instruments and tokenized assets on blockchain networks. It’s powered by the Chainlink Runtime Environment (CRE), which serves as the underlying infrastructure that combines cross-chain interoperability, offchain data integration, and automated compliance orchestration into a single unified offering that enables organizations to:\n",
+    "\n",
+    "- **Use One Identity Everywhere**: vLEI identity and credentials can now work across multiple blockchain networks through CCID\n",
+    "- **Manage your Policies Dynamically**: Update policy rules in real-time without changing your core business applications using ACE’s Policy Manager\n",
+    "- **Protect Privacy**: Keep sensitive information secure off-chain while still executing identity-based checks and rules  on-chain\n",
+    "- **Connect Everything**: Link existing vLEI infrastructure to any blockchain application\n",
+    "\n",
+    "## Why This Matters for vLEI Users\n",
+    "\n",
+    "### Your Credentials, Extended\n",
+    "If your organization already has vLEI credentials, you've invested in establishing a verified, trusted digital identity. Chainlink ACE extends this investment by making your credentials work in blockchain applications without additional verification processes.\n",
+    "\n",
+    "Think of it this way:\n",
+    "- **vLEI** = Your verified organizational identity\n",
+    "- **Cross-Chain Identity (CCID) Framework** = The translator that makes your identity work on blockchains\n",
+    "\n",
+    "## 📚 Visit the [Chainlink Automated Compliance Engine](https://chain.link/automated-compliance-engine) product page: \n",
+    "\n",
+    "#### Ready to extend your vLEI credentials to blockchain?\n",
+    "\n",
+    "Visit [https://chain.link/automated-compliance-engine](https://chain.link/automated-compliance-engine) to explore how the Chainlink Automated Compliance Engine can transform your approach to digital compliance.\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
Adds the chainlink training content from [here](https://docs.google.com/document/d/1QuADYmXhA45OUA97zmKkpl4glmVbM5EvjaQhsm_yz-Y/edit?tab=t.0)