### PR TITLE
fix(notebooks): add libsodium preload and pin signify-ts version

### DIFF
--- a/jupyter/notebooks/102_10_KERIA_Signify_Basic_Operations.ipynb
+++ b/jupyter/notebooks/102_10_KERIA_Signify_Basic_Operations.ipynb
@@ -4,7 +4,6 @@
    "cell_type": "markdown",
    "id": "d93e14db-c930-42e9-96f6-6e4680dc00b7",
    "metadata": {
-    "editable": false,
     "slideshow": {
      "slide_type": ""
     },
@@ -98,7 +97,8 @@
    },
    "outputs": [],
    "source": [
-    "import { randomPasscode, ready, SignifyClient, Tier } from 'npm:signify-ts';\n",
+    "import \"npm:libsodium-wrappers-sumo@0.7.15\";  // Load this first\n",
+    "import { randomPasscode, ready, SignifyClient, Tier } from \"npm:signify-ts@^0.3.0-rc1\";\n",
     "\n",
     "await ready();\n",
     "\n",

--- a/jupyter/notebooks/102_15_KERIA_Signify_Connecting_Clients.ipynb
+++ b/jupyter/notebooks/102_15_KERIA_Signify_Connecting_Clients.ipynb
@@ -68,7 +68,8 @@
    },
    "outputs": [],
    "source": [
-    "import { randomPasscode, ready, SignifyClient, Tier } from 'npm:signify-ts';\n",
+    "import \"npm:libsodium-wrappers-sumo@0.7.15\";  // Load this first\n",
+    "import { randomPasscode, ready, SignifyClient, Tier } from \"npm:signify-ts@^0.3.0-rc1\";\n",
     "\n",
     "const url = 'http://keria:3901';\n",
     "const bootUrl = 'http://keria:3903';\n",

--- a/jupyter/notebooks/102_17_KERIA_Signify_Key_Rotation.ipynb
+++ b/jupyter/notebooks/102_17_KERIA_Signify_Key_Rotation.ipynb
@@ -89,7 +89,8 @@
    },
    "outputs": [],
    "source": [
-    "import { randomPasscode, RotateIdentifierArgs, SignifyClient} from 'npm:signify-ts';\n",
+    "import \"npm:libsodium-wrappers-sumo@0.7.15\";  // Load this first\n",
+    "import { randomPasscode, RotateIdentifierArgs, SignifyClient } from \"npm:signify-ts@^0.3.0-rc1\";\n",
     "import { \n",
     "         initializeAndConnectClient,\n",
     "         createNewAID,\n",

--- a/jupyter/notebooks/102_20_KERIA_Signify_Credential_Issuance.ipynb
+++ b/jupyter/notebooks/102_20_KERIA_Signify_Credential_Issuance.ipynb
@@ -92,7 +92,8 @@
    },
    "outputs": [],
    "source": [
-    "import { randomPasscode, Serder} from 'npm:signify-ts';\n",
+    "import \"npm:libsodium-wrappers-sumo@0.7.15\";\n",
+    "import { randomPasscode, Serder } from \"npm:signify-ts@^0.3.0-rc1\";\n",
     "import { initializeSignify, \n",
     "         initializeAndConnectClient,\n",
     "         createNewAID,\n",

--- a/jupyter/notebooks/102_25_KERIA_Signify_Credential_Presentation_and_Revocation.ipynb
+++ b/jupyter/notebooks/102_25_KERIA_Signify_Credential_Presentation_and_Revocation.ipynb
@@ -77,7 +77,8 @@
    },
    "outputs": [],
    "source": [
-    "import { randomPasscode, Serder} from 'npm:signify-ts';\n",
+    "import \"npm:libsodium-wrappers-sumo@0.7.15\";  // Load this first\n",
+    "import { randomPasscode, Serder} from \"npm:signify-ts@^0.3.0-rc1\";\n",
     "import { initializeSignify, \n",
     "         initializeAndConnectClient,\n",
     "         createNewAID,\n",

--- a/jupyter/notebooks/103_10_vLEI_Trust_Chain.ipynb
+++ b/jupyter/notebooks/103_10_vLEI_Trust_Chain.ipynb
@@ -80,7 +80,8 @@
    },
    "outputs": [],
    "source": [
-    "import { randomPasscode, Saider} from 'npm:signify-ts@0.3.0-rc1';\n",
+    "import \"npm:libsodium-wrappers-sumo@0.7.15\"; \n",
+    "import { randomPasscode, Saider } from \"npm:signify-ts@^0.3.0-rc1\";\n",
     "import { \n",
     "  initializeSignify, initializeAndConnectClient, createNewAID, addEndRoleForAID,\n",
     "  generateOOBI, resolveOOBI, createCredentialRegistry, issueCredential,\n",
@@ -1253,7 +1254,7 @@
    "name": "typescript",
    "nbconvert_exporter": "script",
    "pygments_lexer": "typescript",
-   "version": "5.9.2"
+   "version": "5.8.3"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
This pull request updates several Jupyter notebooks to improve TypeScript dependency management and ensure compatibility with the latest APIs. The main changes include explicitly loading the `libsodium-wrappers-sumo` library before importing `signify-ts`, updating `signify-ts` imports to use a version range, and a minor TypeScript version adjustment in one notebook.

**Dependency management improvements:**

* All relevant notebooks now explicitly import `libsodium-wrappers-sumo@0.7.15` before any `signify-ts` imports to ensure cryptographic dependencies are loaded in the correct order. [[1]](diffhunk://#diff-d0ca321cf1e16d07213fdac966c794bb63cdad366a7bfafddd5f5aaaace907e4L71-R72) [[2]](diffhunk://#diff-93a62977ec0ac6943d3da17b99c382ba3e9a012e7449cd94ef7127895f99bc6eL92-R93) [[3]](diffhunk://#diff-aebfb978847f260c87e981b706f93f96ed7ec266b133bfa2a5e0e0259b4fd22eL95-R96) [[4]](diffhunk://#diff-87fb44a60d0bed0b7f5cd7fae56c3620a9d2e60bfee0720d99332a0758725fe1L80-R81) [[5]](diffhunk://#diff-1babfa739e5b8fb44c007a8afaa9133da4b72345f89add79cca4b919cf5dd0c3L83-R84) [[6]](diffhunk://#diff-5a7bf6939474d3b39fd036c3db66d01a96f0501b53636b339b3d9b13a0ed8121L101-R101)

* Updated all `signify-ts` imports to use the version specifier `@^0.3.0-rc1` for improved compatibility and future-proofing, replacing fixed or unversioned imports. [[1]](diffhunk://#diff-d0ca321cf1e16d07213fdac966c794bb63cdad366a7bfafddd5f5aaaace907e4L71-R72) [[2]](diffhunk://#diff-93a62977ec0ac6943d3da17b99c382ba3e9a012e7449cd94ef7127895f99bc6eL92-R93) [[3]](diffhunk://#diff-aebfb978847f260c87e981b706f93f96ed7ec266b133bfa2a5e0e0259b4fd22eL95-R96) [[4]](diffhunk://#diff-87fb44a60d0bed0b7f5cd7fae56c3620a9d2e60bfee0720d99332a0758725fe1L80-R81) [[5]](diffhunk://#diff-1babfa739e5b8fb44c007a8afaa9133da4b72345f89add79cca4b919cf5dd0c3L83-R84) [[6]](diffhunk://#diff-5a7bf6939474d3b39fd036c3db66d01a96f0501b53636b339b3d9b13a0ed8121L101-R101)

**Notebook metadata and configuration:**

* In `102_10_KERIA_Signify_Basic_Operations.ipynb`, removed the `"editable": false` metadata field from a markdown cell, allowing edits.

* In `103_10_vLEI_Trust_Chain.ipynb`, downgraded the TypeScript kernel version from `5.9.2` to `5.8.3` in the notebook metadata, possibly for compatibility reasons.- Add libsodium-wrappers-sumo@0.7.15 import before signify-ts to ensure proper dependency loading order
- Pin signify-ts to ^0.3.0-rc1 across all training notebooks